### PR TITLE
add add_word and remove_word to Newmm Tokenizer

### DIFF
--- a/src/tokenizer/trie_char_ver.rs
+++ b/src/tokenizer/trie_char_ver.rs
@@ -67,7 +67,7 @@ impl TrieNode {
         let mut word = input_word;
         let char_count = word.chars_len();
         // if has atleast 1 char
-        if word.chars_len() >= BYTES_PER_CHAR {
+        if word.chars_len() >= 1 {
             let character = word.get_chars_content().get(0).unwrap();
             if let Some(child) = self.find_mut_child(character) {
                 // move 1 character
@@ -76,8 +76,8 @@ impl TrieNode {
                 if char_count == 1 {
                     child.set_not_end();
                 }
-                child.remove_word_from_node(word);
                 word = &substring_of_word;
+                child.remove_word_from_node(word);
                 if !child.end && child.children.is_empty() {
                     self.remove_child(character);
                 }
@@ -125,7 +125,6 @@ impl TrieChar {
             self.root.remove_word_from_node(&stripped_word);
         }
     }
-
 
     pub fn contain(&self, word: &CustomString) -> bool {
         self.words.contains(word.raw_content())

--- a/tests/test_tokenizer.rs
+++ b/tests/test_tokenizer.rs
@@ -1,9 +1,9 @@
-use nlpo3::tokenizer::newmm_custom::{Newmm as NewmmCustom};
+use nlpo3::tokenizer::newmm_custom::Newmm as NewmmCustom;
 use nlpo3::tokenizer::tokenizer_trait::Tokenizer;
 const FIRST_TEXT: &str = "นิสสันผ่อนจนเพลียนาวาร่า..";
 const SECOND_TEXT: &str =
     "อาชญากรรมทางการแพทย์.. หลอกลวงคนไข้ผ่าตัด ตัดหมอนรองข้อเข่าอำพราง รพ.กรุงเทพภูเก็ตปลอมเวชระเบียน ตอนที่๑.";
-const DEFAULT_DICT_PATH: &str =  "/words_th.txt"; // relative to cargo
+const DEFAULT_DICT_PATH: &str = "/words_th.txt"; // relative to cargo
 #[test]
 fn test_long_text_byte_tokenizer() {
     let mut relative_test_dict_path = env!("CARGO_MANIFEST_DIR").to_string();
@@ -152,12 +152,8 @@ fn test_long_text_byte_tokenizer() {
     ]
     .join("");
     let newmm_default_dict = NewmmCustom::new(&relative_test_dict_path);
-    let result = newmm_default_dict
-        .segment(&long_text, false, true)
-        .unwrap();
-    let safe_result = newmm_default_dict
-        .segment(&long_text, true, true)
-        .unwrap();
+    let result = newmm_default_dict.segment(&long_text, false, true).unwrap();
+    let safe_result = newmm_default_dict.segment(&long_text, true, true).unwrap();
     assert_eq!(result.len(), 1889);
     assert_eq!(safe_result.len(), 1991);
 }
@@ -189,6 +185,23 @@ fn test_standard_short_word() {
     assert_eq!(
         newmm_default_dict.segment_to_string("USD1,984.42", false, false),
         ["USD", "1,984.42"]
+    );
+}
+#[test]
+fn test_with_add_or_remove_word() {
+    let mut relative_test_dict_path = env!("CARGO_MANIFEST_DIR").to_string();
+    relative_test_dict_path.push_str(DEFAULT_DICT_PATH);
+    let mut newmm_default_dict = NewmmCustom::new(&relative_test_dict_path);
+    newmm_default_dict.add_word(&["ฉันรักภาษาไทยเพราะฉันเป็นคนไทย"]); // exaggerated word
+    assert_eq!(
+        newmm_default_dict.segment_to_string("ฉันรักภาษาไทยเพราะฉันเป็นคนไทย", false, false),
+        ["ฉันรักภาษาไทยเพราะฉันเป็นคนไทย"]
+    );
+    newmm_default_dict.remove_word(&["ฉันรักภาษาไทยเพราะฉันเป็นคนไทย"]); // exaggerated word
+    newmm_default_dict.remove_word(&["ภาษาไทย"]); // exaggerated word
+    assert_eq!(
+        newmm_default_dict.segment_to_string("ฉันรักภาษาไทยเพราะฉันเป็นคนไทย", false, false),
+        ["ฉัน", "รัก", "ภาษา", "ไทย", "เพราะ", "ฉัน", "เป็น", "คนไทย"]
     );
 }
 #[test]
@@ -257,5 +270,3 @@ fn test_thai_number() {
         ["USD", "๑,๙๘๔.๔๒"]
     );
 }
-
-


### PR DESCRIPTION
This might be what you want exactly.

For binding, the simplest way is .... like this

```rust
/// lib.rs in binding

#[pyfunction]
fn add_word(dict_name: &str,words:Vec<&str>) -> PyResult<(String,bool)> {
    let mut dict_col_lock = DICT_COLLECTION.lock().unwrap();
    if let Some(newmm_dict) = dict_col_lock.get(dict_name) {
        newmm_dict.add_word(&words);
        Ok((format!(
           "Add new word(s) successfully."
        ),true))
    } else {
       Ok((format!("Cannot add new word(s) - dictionary instance named '{}' does not exist.",dict_name),false))
    }
}
#[pyfunction]
fn remove_word(dict_name: &str,words:Vec<&str>) -> PyResult<(String,bool)> {
    let mut dict_col_lock = DICT_COLLECTION.lock().unwrap();
    if let Some(newmm_dict) = dict_col_lock.get(dict_name) {
        newmm_dict.remove_word(&words);
        Ok((format!(
           "Remove word(s) successfully."
        ),true))
    } else {
       Ok((format!("Cannot remove word(s) - dictionary instance named '{}' does not exist.",dict_name),false))
    }
}


```
Then use it like this

``` python3

load_dict(PATH_TO_DICT, "my_dict")

add_word("my_dict", ["กขคง"]]



```

---

The ideal way for binding in general and in the future may be to add binding function which returns an instance of dict as an object of the target language, and let the target language code  call its method ... like this

``` python3
from nlpo3 import * as o3
o3.load_dict(PATH_TO_FILE, "my_dict")
my_dict = get_dict("my_dict")

my_dict.add_word(["กขคง"])

tokens = my_dict.tokenize("กขคงกขคง")
 


```